### PR TITLE
Use github actions for CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "*"
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    env:
+      MIX_ENV: test
+
+    name: Lint
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "24"
+          elixir-version: "1.13"
+
+      - uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - run: mix deps.get
+      - run: mix deps.compile
+      - run: mix format --check-formatted
+      - run: mix deps.unlock --check-unused
+
+  test:
+    runs-on: ${{ matrix.os }}
+    env:
+      MIX_ENV: test
+
+    name: Test Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}, OS ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+         - ubuntu-20.04
+        elixir:
+          - "1.13"
+          - "1.12"
+          - "1.11"
+          - "1.10"
+        otp:
+          - "24"
+          - "23"
+          - "21"
+        include:
+          - os: windows-2019
+            elixir: "1.13"
+            otp: "24"
+          - os: windows-2019
+            elixir: "1.12"
+            otp: "24"
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      - uses: egor-tensin/vs-shell@v2
+        if: runner.os == 'Windows'
+
+      - uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - run: mix deps.get --only test
+      - run: mix deps.compile
+      - run: mix compile
+      - run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         otp:
           - "24"
           - "23"
-          - "21"
+          - "22"
         include:
           - os: windows-2019
             elixir: "1.13"


### PR DESCRIPTION
This is a similar setup to what we have running for `exqlite` and `ecto_sqlite3`.

Also adds compilation in windows.

CI time is free for opensource projects.